### PR TITLE
Artifact Download Path

### DIFF
--- a/.github/workflows/python-deploy-artifacts.yml
+++ b/.github/workflows/python-deploy-artifacts.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: aac_puml_wheel
-          path: python/dist/
+          path: dist/
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aac-puml"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
 	{ name="crazynewidea", email="asdfasdf@mail.com" },
     { name="lizzcondrey", email="asdfasdfd@mail.com" },


### PR DESCRIPTION
# Description

Trying to get artifact download path to agree with pypi upload action

# Linked Items:

Closes/Fixes/Resolves #23 

### Changed

-  Download artifact path to agree with expected location of pypi upload action

# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [x] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
